### PR TITLE
Abbreviate too long strings for display elements

### DIFF
--- a/Database.cs
+++ b/Database.cs
@@ -49,6 +49,17 @@ namespace VRCSaveHelper
         {
             get { return data; }
         }
+
+        public string DisplayData
+        {
+            get
+            {
+                var limit = 500;
+                var tmp = data.Replace("\r", "").Replace("\n", "");
+                if (tmp.Length < limit) { return tmp; }
+                return tmp.Substring(0, limit) + "...";
+            }
+        }
     }
 
     public class WorldViewModel : INotifyPropertyChanged

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -34,7 +34,7 @@
             <ListView.View>
                 <GridView>
                     <GridViewColumn Header="Timestamp" Width="150" DisplayMemberBinding="{Binding DisplayTimestamp}"></GridViewColumn>
-                    <GridViewColumn Header="Data" Width="600" DisplayMemberBinding="{Binding Data}"></GridViewColumn>
+                    <GridViewColumn Header="Data" Width="600" DisplayMemberBinding="{Binding DisplayData}"></GridViewColumn>
                 </GridView>
             </ListView.View>
         </ListView>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -160,7 +160,7 @@ namespace VRCSaveHelper
                 _viewModel.SelectedHistory = history;
                 new ToastContentBuilder()
                     .AddText(world.Name)
-                    .AddText("Saved: " + data)
+                    .AddText("Saved: " + history.DisplayData)
                     .Show();
             }
         }
@@ -250,11 +250,11 @@ namespace VRCSaveHelper
             var history = world.History;
             if (history.Count > 0 && world.AutoLoad)
             {
-                var data = history[history.Count - 1].Data;
-                SetClipboardText(data);
+                var item = history[history.Count - 1];
+                SetClipboardText(item.Data);
                 new ToastContentBuilder()
                     .AddText(world.Name)
-                    .AddText("Copied: " + data)
+                    .AddText("Copied: " + item.DisplayData)
                     .Show();
             }
             _viewModel.SelectedWorld = world;


### PR DESCRIPTION
Using very long string for display elements (toast and list box) causes crash or slowdown.
This PR abbreviates the data for display elements to fix the problem.